### PR TITLE
Allow easy restoral of all mocked services.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function stubMethod(service, method, replacement) {
   if (!isStubbed(service)) stubService(service);
   if (!replacement) return sinon.stub(getService(service).prototype, method);
 
-  return sinon.stub(getService(service).prototype, method, function(params, callback) {
+  return sinon.stub(getService(service).prototype, method).callsFake(function(params, callback) {
     var _this = { request: stubRequest(), response: stubResponse() };
     replacement.call(_this, params, callback);
     return _this.request;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 var events = require('events');
-var sinon = require('sinon');
+var sinon = require('sinon').sandbox.create();
 var _AWS = require('aws-sdk');
 var traverse = require('traverse');
 
 module.exports = _AWS;
 module.exports.stub = stubMethod;
+module.exports.restore = restoreAll;
 
 /**
  * Replaces a single AWS service method with a stub.
@@ -27,6 +28,10 @@ function stubMethod(service, method, replacement) {
     replacement.call(_this, params, callback);
     return _this.request;
   });
+}
+
+function restoreAll() {
+  return sinon.restore();
 }
 
 function isStubbed(service) {
@@ -61,14 +66,14 @@ function stubService(service) {
 
 function stubRequest() {
   var req = new events.EventEmitter();
-  var stubbed = sinon.createStubInstance(_AWS.Request);
+  var stubbed = sinon.stub(Object.create(_AWS.Request.prototype));
   for (var method in req.__proto__) delete stubbed[method];
   return Object.assign(req, stubbed);
 }
 
 function stubResponse() {
   var req = new events.EventEmitter();
-  var stubbed = sinon.createStubInstance(_AWS.Response);
+  var stubbed = sinon.stub(Object.create(_AWS.Response.prototype));
   for (var method in req.__proto__) delete stubbed[method];
   return Object.assign(req, stubbed);
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.5.0",
-    "sinon": "^1.17.5",
+    "sinon": "^2.2.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -234,6 +234,17 @@ test('[multipleMethods] replacement function', function(assert) {
   });
 });
 
+test('[multipleMethods] restore all', function(assert) {
+  var Original = AWS.S3;
+  AWS.stub('S3', 'putObject', function() {});
+  AWS.stub('S3', 'getObject', function() {});
+
+  assert.equal(AWS.S3 === Original, false, 'service is initially stubbed');
+  AWS.restore();
+  assert.ok(AWS.S3 === Original, 'service is restored');
+  assert.end();
+});
+
 test('[upload] methods inherited multiple times', function(assert) {
   var upload = AWS.stub('S3', 'upload', function(params, callback) {
     callback(null, data);


### PR DESCRIPTION
This PR uses a Sinon sandbox to contain all modifications to the AWS-SDK, which allows a new `restore()` method to restore the SDK back to the original state.

I initially defined the restore function as `module.exports.restore = sinon.restore;`, but this seemed to mislead Istanbul into thinking there was still 100% coverage when I'd just added a new feature without commensurate tests. So I wrapped the restore call in a function and wrote a test to make sure it operates as expected.

**NOTE:** This PR also updates Sinon from v1.x to v2.x. CI isn't currently configured on this fork, but the tests pass when I run them in my clean Vagrant-based development environment.